### PR TITLE
Fixed #9 added configurable timer per node server for short and

### DIFF
--- a/polyglot/nodeserver_api.py
+++ b/polyglot/nodeserver_api.py
@@ -255,13 +255,17 @@ class NodeServer(object):
     The Polyglot Connection
 
     :type: polyglot.nodeserver_api.PolyglotConnector
+    :param shortpoll is the time between poll events (optional)
+    :param longpoll is the time between longpoll events (optional)
     """
 
-    def __init__(self, poly):
+    def __init__(self, poly, shortpoll=1, longpoll=30):
         # create/store properties
         self.poly = poly
         self.config = {}
         self.running = False
+        self.shortpoll = shortpoll
+        self.longpoll = longpoll
 
         # bind callbacks to events
         poly.listen('config', self.on_config)
@@ -430,11 +434,11 @@ class NodeServer(object):
         counter = 0
         try:
             while self.running:
-                time.sleep(1)
+                time.sleep(self.shortpoll)
                 self.poll()
-                counter += 1
+                counter += self.shortpoll
 
-                if counter >= 30:
+                if counter >= self.longpoll:
                     self.long_poll()
                     counter = 0
 


### PR DESCRIPTION
long poll. Pass the parameters to your nodeserver with the polyglot
connector. Like so:

```
poly = PolyglotConnector()
nserver = HueNodeServer(poly, 1, 60)
```

Where 1 is the shortpoll and 60 is the longpoll. These are optional
to perserve backwards compatibility and the defaults are unchanged.
